### PR TITLE
Add the ability to gracefully shutdown the server

### DIFF
--- a/handlers/shutdown_handler.go
+++ b/handlers/shutdown_handler.go
@@ -1,0 +1,21 @@
+package handlers
+
+import (
+    "net/http"
+)
+
+func BuildShutdownHandler(shutdownChan chan bool) func(res http.ResponseWriter, req *http.Request) {
+    return func(res http.ResponseWriter, req *http.Request) {
+        if req.Method == http.MethodPut {
+            // shutdown issued here
+            res.WriteHeader(http.StatusAccepted)
+            res.Write([]byte("shutting down..."))
+            shutdownChan <- true
+        } else {
+            // no more supported methods to match return 404, write header first
+            res.WriteHeader(http.StatusNotFound)
+            res.Write([]byte("404 page not found\n"))
+        }
+    }
+
+    }

--- a/handlers/shutdown_handler_test.go
+++ b/handlers/shutdown_handler_test.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+    "testing"
+    "net/http/httptest"
+    "net/http"
+    "strings"
+)
+
+func TestBuildShutdownHandler(t *testing.T) {
+    shutdown := make(chan bool)
+    ShutdownHandler := BuildShutdownHandler(shutdown)
+    called := make(chan bool)
+    server := httptest.NewServer(http.HandlerFunc(ShutdownHandler))
+
+    go func() {
+        <-shutdown
+        server.Close()
+        called <- true
+    }()
+
+    t.Log("Should start graceful server shutdown on PUT")
+    req, err := http.NewRequest(http.MethodPut, server.URL, strings.NewReader(""))
+    if err != nil {
+        t.Errorf("Failed PUT: %s", err.Error())
+    }
+
+    t.Log("Should respond to client request")
+    res, err := http.DefaultClient.Do(req)
+    if err != nil {
+        t.Errorf("Failed: %s", err.Error())
+    }
+    t.Logf("Should return %d on success", http.StatusAccepted)
+    if res.StatusCode != http.StatusAccepted {
+        t.Errorf("PUT to /shutdown failed; expected %d got %d", http.StatusAccepted, res.StatusCode)
+    }
+
+    t.Log("shutdown channel should be set true, calling shutdown")
+    shutdownCalled := <-called
+    if !shutdownCalled {
+        t.Error("Shutdown was not called")
+    }
+
+    t.Log("Server should no longer exist")
+    if server.Config.Addr != "" {
+        t.Error("Server not closed")
+    }
+
+}

--- a/hash-o-matic.go
+++ b/hash-o-matic.go
@@ -4,15 +4,71 @@ import (
     "github.com/dbyington/hash-o-matic/handlers"
     "log"
     "net/http"
+    "context"
+    "time"
+    "os"
+    "os/signal"
+    "syscall"
 )
 
 const LISTEN_ADDR = ":8080"
-const HASH_URL = "/hash"
 
 func main() {
-    http.HandleFunc(HASH_URL, handlers.HashHandler)
-    log.Fatal(http.ListenAndServe(LISTEN_ADDR,
-        handlers.LogHandler(http.DefaultServeMux)))
+
+    handler := handlers.LogHandler(http.DefaultServeMux)
+    server := &http.Server{Addr: LISTEN_ADDR, Handler: handler}
+
+    // Create a channel and signal notifier to catch OS level interrupts (i.e. ^C)
+    interruptChan := make(chan os.Signal)
+    signal.Notify(interruptChan, os.Interrupt, syscall.SIGTERM)
+
+    // Create a channel and associated handler for PUTs to /shutdown
+    shutdownChan := make(chan bool)
+    ShutdownHandler := handlers.BuildShutdownHandler(shutdownChan)
+
+    // Create channel to signal all done
+    doneChan := make(chan bool)
+
+    // routes
+    http.HandleFunc("/hash", handlers.HashHandler)
+    http.HandleFunc("/shutdown", ShutdownHandler)
+
+    // wait for interrupt or shutdown call
+    go func() {
+
+        select {
+            case n := <-interruptChan:
+                log.Printf("Received signal %s; shutting down\n", n.String())
+                StopServer(server)
+
+            case _ = <-shutdownChan:
+                log.Print("Received call to /shutdown, shutting down\n")
+                StopServer(server)
+        }
+
+        close(doneChan)
+    }()
+
+    log.Printf("Server listening on: %s", server.Addr)
+    err := server.ListenAndServe()
+    if err != http.ErrServerClosed {
+        log.Fatalf("listen: %s\n", err)
+    }
+
+    <-doneChan
+    log.Println("Shutdown complete.")
+
 }
 
+func StopServer(server *http.Server) {
 
+    log.Print("Stopping server")
+    // create context with a timeout of 5 seconds to allow requests in-flight to finish
+    ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Second)
+    defer cancel()
+
+    err := server.Shutdown(ctx)
+    if err != nil {
+        log.Fatalf("Error while shutting down: %s", err)
+    }
+}


### PR DESCRIPTION
The running hash-o-matic server can be stopped with ^C, interrupt, or by sending a PUT request to http://[server address]/shutdown
New connections will be denied while the server waits for current operations to complete.