### PR TITLE
Add hashId and basic db functions

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -1,0 +1,27 @@
+package database
+
+import (
+    "github.com/dbyington/hash-o-matic/database/memory"
+)
+
+
+type Database interface {
+    GetNextId() (Id int, err error)
+    SaveHashWithId(hashString string, Id int) (realId int, err error)
+    GetHashById(Id int) (hashString string, err error)
+}
+
+var DB = new(memory.MemoryDatabase)
+
+var dbInterface = Database(DB)
+var GetNextId = dbInterface.GetNextId
+var GetHashById = dbInterface.GetHashById
+var SaveHashWithId = dbInterface.SaveHashWithId
+
+/*
+Methods needed:
+GetNextId() (int, err)
+GetHashById(Id) (hashString, err)
+GetHashIdByHash(hashString) (hashString, err)
+SaveHashWithId(hashString, Id) (err)
+ */

--- a/database/memory/memory.go
+++ b/database/memory/memory.go
@@ -1,0 +1,59 @@
+package memory
+
+import (
+    "time"
+    "log"
+    "errors"
+)
+
+type HashRecord struct {
+    Hash string
+    Ready bool
+    Created time.Time
+}
+
+type MemoryDatabase struct {}
+
+var Hashes []HashRecord
+
+func (m MemoryDatabase) GetNextId() (Id int, err error) {
+    Hashes = append(Hashes, HashRecord{})
+    Id = len(Hashes)
+    realId, _ := checkId(Id)
+    Hashes[realId].Ready = false
+    Hashes[realId].Created = time.Now()
+    return Id, err
+}
+
+func checkId(Id int) (realId int, err error) {
+    // the real Id is Id-1, since Id is the length of the array
+    if len(Hashes) >= Id {
+        realId = Id - 1
+    } else {
+        log.Printf("Id check failed: %d is invalid.\n", Id)
+        return 0, errors.New("Bad Id")
+    }
+    return realId, nil
+}
+
+func (m MemoryDatabase) SaveHashWithId(hashString string, Id int) (realId int, err error) {
+    realId, idErr := checkId(Id)
+    if idErr != nil {
+        return 0, idErr
+    }
+    Hashes[realId].Hash = hashString
+    Hashes[realId].Ready = true
+    return Id, err
+}
+
+func (m MemoryDatabase) GetHashById(Id int) (hashString string, err error) {
+    realId, idErr := checkId(Id)
+    if idErr != nil {
+        return "", idErr
+    }
+    if Hashes[realId].Ready {
+        hashString = Hashes[realId].Hash
+        return hashString, err
+    }
+    return "", errors.New("hash string not ready")
+}

--- a/database/memory/memory_test.go
+++ b/database/memory/memory_test.go
@@ -1,0 +1,79 @@
+package memory
+
+import (
+    "testing"
+    //"time"
+    //"os"
+)
+
+
+type Database interface {
+    GetNextId() (Id int, err error)
+    SaveHashWithId(hashString string, Id int) (realId int, err error)
+    GetHashById(Id int) (hashString string, err error)
+}
+
+var DB = new(MemoryDatabase)
+
+var dbi = Database(DB)
+
+var hashString = "ZEHhWB65gUlzdVwtDQArEyx+KVLzp/aTaRaPlBzYRIFj6vjFdqEb0Q5B8zVKCZ0vKbZPZklJz0Fd7su2A+gf7Q=="
+var reversedHashString = "==Q7fg+A2us7dF0zJlkZPZbKv0ZCKVz8B5Q0bEqdFjv6jFIRYzBlPaRaTa/pzLVK+xyErAQDtwVdzlUg56BWhHEZ"
+
+//func TestMain(m *testing.M) {
+//    if len(Hashes) != 0 {
+//        Hashes = []HashRecord{}
+//    }
+//    code := m.Run()
+//    os.Exit(code)
+//}
+
+func TestGetNextId(t *testing.T) {
+    Id, err := dbi.GetNextId()
+    if err != nil || Id != 1 {
+        t.Errorf("Error getting first Id; expected 1 got %d", Id)
+    }
+}
+
+func TestSaveHashWithId(t *testing.T) {
+    Id, err := dbi.GetNextId()
+    if err != nil {
+        t.Error("Failed to get next Id:", err)
+    }
+
+    Id, err = dbi.SaveHashWithId(hashString, Id)
+    if err != nil {
+        t.Error("Error saving hashString:", err)
+    }
+    Id, err = dbi.GetNextId()
+    savedId, err := dbi.SaveHashWithId(reversedHashString, Id)
+    if err != nil {
+        t.Error("Error saving hashString:", err)
+    }
+
+    if err != nil {
+        t.Error("Failed to get next Id:", err)
+    }
+    if savedId != Id {
+        t.Errorf("Failed to save hashString; expected Id %d got %d\n", Id, savedId)
+    }
+}
+
+func TestGetHashById(t *testing.T) {
+    Id, err := dbi.GetNextId()
+    returnId, err := dbi.SaveHashWithId(hashString, Id)
+    if err != nil || returnId != Id{
+        t.Error("Error saving hashString:", err, returnId)
+    }
+    Id, err = dbi.GetNextId()
+    returnId, err = dbi.SaveHashWithId(reversedHashString, Id)
+
+    testId := returnId - 1
+    savedHash, err := dbi.GetHashById(testId)
+    if err != nil {
+        t.Error("Problem getting hash", err)
+    }
+    if savedHash != hashString {
+        t.Errorf("Saved hash mismatch; expected %s got %s\n", hashString, savedHash)
+    }
+}

--- a/handlers/hash_handler.go
+++ b/handlers/hash_handler.go
@@ -4,32 +4,93 @@ import (
     "net/http"
     "time"
     "github.com/dbyington/hash-o-matic/util"
+    "github.com/dbyington/hash-o-matic/database"
     "strings"
+    "encoding/json"
+    "regexp"
+    "strconv"
 )
 
 const FORM_KEY = "password"
 
+type HashIdReply struct {
+    HashId int
+}
+
+type HashStringReply struct {
+    HashString string
+}
+
+type ErrorReply struct {
+    ErrorMessage string
+}
 func HashHandler(res http.ResponseWriter, req *http.Request) {
-    if req.Method == http.MethodPost {
+    switch req.Method {
+    case http.MethodPost:
         HashPostMethod(res, req)
         return
+    case http.MethodGet:
+        HashGetMethod(res, req)
+        return
+    default:
+        // no more supported methods to match return 404, write header first
+        ReplyNotFound(res)
     }
-
-    // no more supported methods to match return 404, write header first
+}
+func ReplyNotFound(res http.ResponseWriter) {
     res.WriteHeader(http.StatusNotFound)
-    res.Write([]byte("404 page not found\n"))
+    errorReply := ErrorReply{ ErrorMessage: "Page not found"}
+    json.NewEncoder(res).Encode(errorReply)
 }
 
 func HashPostMethod(res http.ResponseWriter, req *http.Request) {
     req.ParseForm()
     password, exists := req.PostForm[FORM_KEY]
     if exists {
-        // requisite sleep, simulate slow connection
-        time.Sleep(5 * time.Second)
-        res.WriteHeader(http.StatusCreated)
-        res.Write([]byte(util.HashString(strings.Join(password, ""))))
+        hashId, err := database.GetNextId()
+        if err != nil {
+            res.WriteHeader(http.StatusInternalServerError)
+            res.Write([]byte("Error getting next hash id:" + err.Error()))
+        }
+        res.WriteHeader(http.StatusAccepted)
+        var jsonReply HashIdReply
+        jsonReply.HashId = hashId
+        json.NewEncoder(res).Encode(jsonReply)
+        go SaveHash(strings.Join(password, ""), hashId)
     } else {
         res.WriteHeader(http.StatusBadRequest)
         res.Write([]byte("Missing key " + FORM_KEY))
     }
+}
+
+func SaveHash(passwd string, Id int) {
+    time.Sleep(5 * time.Second)
+    hashString := util.HashString(passwd)
+    database.SaveHashWithId(hashString, Id)
+}
+
+func HashGetMethod(res http.ResponseWriter, req *http.Request) {
+    rexp := regexp.MustCompile("[0-9]+$")
+    id := rexp.FindString(req.RequestURI)
+    hashId, err := strconv.Atoi(id)
+    if err != nil {
+        ReplyNotFound(res)
+        return
+    }
+
+    if hashId > 0 {
+        var jsonReply HashStringReply
+        var err error
+        jsonReply.HashString, err = database.GetHashById(hashId)
+        if err != nil {
+            jsonErr := ErrorReply{ ErrorMessage: err.Error() }
+            res.WriteHeader(http.StatusAccepted)
+            json.NewEncoder(res).Encode(jsonErr)
+            return
+        }
+        res.WriteHeader(http.StatusOK)
+        json.NewEncoder(res).Encode(jsonReply)
+        return
+    }
+    ReplyNotFound(res)
 }

--- a/handlers/hash_handler_test.go
+++ b/handlers/hash_handler_test.go
@@ -4,9 +4,10 @@ import (
     "net/http"
     "testing"
     "net/url"
-    "io/ioutil"
     "net/http/httptest"
     "strings"
+    "encoding/json"
+    "time"
 )
 
 const HASH_URL = "/hash"
@@ -21,21 +22,22 @@ func TestHashPostMethod(t *testing.T) {
     body := url.Values{}
     body.Set("password", "angryMonkey")
 
-    t.Log("Valid request should return 201")
+    t.Log("Should return", http.StatusAccepted)
     res, err := http.PostForm(server.URL, body)
     defer res.Body.Close()
     if err != nil {
         t.Error(err)
     }
-    if res.StatusCode != http.StatusCreated {
-        t.Errorf("POST to %s failed; expected %d got %d\n", HASH_URL, http.StatusCreated, res.StatusCode)
+    if res.StatusCode != http.StatusAccepted {
+        t.Errorf("POST to %s failed; expected %d got %d\n", HASH_URL, http.StatusAccepted, res.StatusCode)
     }
-    resBody, err := ioutil.ReadAll(res.Body)
-    if string(resBody) != HASH_EXPECTED {
-        t.Errorf("Bad response; expected '%s' got '%s'", HASH_EXPECTED, string(resBody))
+    var resBody HashIdReply
+    json.NewDecoder(res.Body).Decode(&resBody)
+    if resBody.HashId != 1 {
+        t.Errorf("Bad response; expected 1 got '%d'", resBody.HashId)
     }
 
-    t.Log("No form data should return 400")
+    t.Log("Should return 400 on empty post")
     res, err = http.PostForm(server.URL, url.Values{})
     if err != nil {
         t.Error(err)
@@ -51,7 +53,7 @@ func TestHashHandler(t *testing.T) {
     server := httptest.NewServer(http.HandlerFunc(HashHandler))
     defer server.Close()
 
-    t.Log("PUT to /hash should return 404")
+    t.Log("Should return 404 on PUT to /hash")
     req, err := http.NewRequest(http.MethodPut, server.URL, strings.NewReader(""))
     req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
     res, err := http.DefaultClient.Do(req)
@@ -62,7 +64,7 @@ func TestHashHandler(t *testing.T) {
         t.Errorf("PUT to %s; expected %d got %d\n", HASH_URL, http.StatusNotFound, res.StatusCode)
     }
 
-    t.Logf("GET to /hash should return 404")
+    t.Logf("Should return 404 on GET to /hash")
     req, err = http.NewRequest(http.MethodGet, server.URL, strings.NewReader(""))
     res, err = http.DefaultClient.Do(req)
     if err != nil {
@@ -72,4 +74,58 @@ func TestHashHandler(t *testing.T) {
         t.Errorf("GET to %s; expected %d got %d\n", HASH_URL, http.StatusNotFound, res.StatusCode)
     }
 
+}
+
+func TestHashGetMethod(t *testing.T) {
+
+    server := httptest.NewServer(http.HandlerFunc(HashHandler))
+    defer server.Close()
+
+    body := url.Values{}
+    body.Set("password", "angryMonkey")
+
+    res, err := http.PostForm(server.URL, body)
+    defer res.Body.Close()
+    if err != nil {
+        t.Error(err)
+    }
+    if res.StatusCode != http.StatusAccepted {
+        t.Errorf("POST to %s failed; expected %d got %d\n", HASH_URL, http.StatusAccepted, res.StatusCode)
+    }
+
+    var resHashId HashIdReply
+    json.NewDecoder(res.Body).Decode(&resHashId)
+    t.Log("Got hashId:", resHashId.HashId)
+    if resHashId.HashId < 1 {
+        t.Errorf("POST failed; expected int returnd got %s")
+    }
+
+    var resHashString HashStringReply
+    t.Logf("Should return %d on early GET to /hash/%d", http.StatusAccepted, resHashId.HashId)
+    getUrl := server.URL + "/hash/" + string(resHashId.HashId)
+    res, err = http.Get(getUrl)
+    if err != nil {
+        t.Error(err)
+    }
+    if res.StatusCode != http.StatusAccepted {
+        t.Errorf("GET to %s; expected %d got %d\n", getUrl, http.StatusAccepted, res.StatusCode)
+    }
+    json.NewDecoder(res.Body).Decode(&resHashString)
+    if resHashString.HashString != "" {
+        t.Error("Expected hash string to be empty, got:", resHashString.HashString)
+    }
+
+    t.Log("Should return 200 after 5 seconds")
+    time.Sleep(5*time.Second)
+    res, err = http.Get(getUrl)
+    if err != nil {
+        t.Error(err)
+    }
+    if res.StatusCode != http.StatusOK {
+        t.Errorf("GET to %s; expected %d got %d\n", getUrl, http.StatusOK, res.StatusCode)
+    }
+    json.NewDecoder(res.Body).Decode(&resHashString)
+    if resHashString.HashString != HASH_EXPECTED {
+        t.Errorf("Hash mismatch; expected %s got %s", HASH_EXPECTED, resHashString.HashString)
+    }
 }

--- a/hash-o-matic.go
+++ b/hash-o-matic.go
@@ -30,7 +30,10 @@ func main() {
     doneChan := make(chan bool)
 
     // routes
+    // If only '/hash/' was configured requests to '/hash' would be redirected
+    // that should not happen, hence the separate routes
     http.HandleFunc("/hash", handlers.HashHandler)
+    http.HandleFunc("/hash/", handlers.HashHandler)
     http.HandleFunc("/shutdown", ShutdownHandler)
 
     // wait for interrupt or shutdown call


### PR DESCRIPTION
POST to /hash now returns a json object with the key HashId, the value of which is an identifier to be used on a GET.
GETs to /hash/{id} now return a json object with the key HashString, the value of is the hash from the earlier POST.
If the hash has not been saved to the database, or is otherwise not ready, the GET will return '{"ErrorMessage":"hash string not ready"}'