### PR TITLE
add back the vendor info for heroku

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,0 +1,10 @@
+{
+  "comment": "Just me playing with go, git, github... and heroku",
+  "ignore": "test",
+  "package": [],
+  "rootPath": "github.com/dbyington/hash-o-matic",
+  "heroku": {
+    "install" : [ "./..." ],
+    "goVersion" : "go1.10"
+  }
+}


### PR DESCRIPTION
Oops. Probably shouldn't have deleted that.